### PR TITLE
ci: fix goreleaser legacy config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
 archives:
 - id: manager
   name_template: "manager_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - manager
 
 checksum:


### PR DESCRIPTION
## Current situation
renovate merged an incompatible upgrade of the goreleaser action.

## Proposal
Align goreleaser config and replace removed fields.
